### PR TITLE
Emit log events as :warning instead of :warn

### DIFF
--- a/lib/syslog.ex
+++ b/lib/syslog.ex
@@ -22,6 +22,13 @@ defmodule Logger.Backends.Syslog do
   end
 
   def handle_event({level, _gl, {Logger, msg, ts, md}}, %{level: min_level} = state) do
+    # using :warn produces a deprecation warning from Logger since Elixir v1.15
+    level =
+      case level do
+        :warn -> :warning
+        level -> level
+      end
+
     if is_nil(min_level) or Logger.compare_levels(level, min_level) != :lt do
       log_event(level, msg, ts, md, state)
     end


### PR DESCRIPTION
In Elixir v1.15 a deprecation warning is emitted if the deprecated log level shortcut `warn` is:

```
warning: the log level :warn is deprecated, use :warning instead
  (logger 1.15.7) lib/logger.ex:1137: Logger.elixir_level_to_erlang_level/1
  (logger 1.15.7) lib/logger.ex:591: Logger.compare_levels/2
  (syslog 1.0.0) lib/syslog.ex:37: Logger.Backends.Syslog.handle_event/2
  (stdlib 5.2) gen_event.erl:814: :gen_event.server_update/4
  (stdlib 5.2) gen_event.erl:796: :gen_event.server_notify/4
  (stdlib 5.2) gen_event.erl:538: :gen_event.handle_msg/6
```

At the same time the `Logger` passes the log level as `warn` to the [old-style logger backends](https://hexdocs.pm/logger/1.15/Logger.html#module-backends-and-backwards-compatibility). Presumably for backwards compatibility. It thus falls to the logger backend to use the correct level identifier when emitting events.

The `syslog` backend is such a logger backend. This PR adds a code snippet to transform the received level `warn` to `warning`.

cc: @harunzengin @weisslj 